### PR TITLE
Update babel dependencies to fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-svg-converter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "CLI and module for converting SVG's to usable React Components.",
   "repository": {
     "type": "git",
@@ -12,8 +12,8 @@
     "react-svg-converter": "./bin/index.js"
   },
   "dependencies": {
-    "babel": "^6.3.13",
     "babel-cli": "^6.3.17",
+    "babel-core": "^6.18.2",
     "babel-plugin-transform-regenerator": "^6.3.18",
     "babel-polyfill": "^6.3.14",
     "babel-preset-es2015": "^6.3.13",


### PR DESCRIPTION
Babel moved CLI commands to separate npm package `babel-cli`. Local mocha tests were not passing, so this PR updates dependencies to get them working again.